### PR TITLE
feat: use temp file for request body

### DIFF
--- a/lua/ai/init.lua
+++ b/lua/ai/init.lua
@@ -16,13 +16,21 @@ local function curl_command(url, api_key, request)
   if type(json_request) ~= "string" then
     error("Error while parsing the request")
   end
+
+  -- create temporary file for JSON data
+  local tmpfile = vim.fn.tempname()
+  local ok = vim.fn.writefile({ json_request }, tmpfile)
+  if ok ~= 0 then
+    error("Failed to write request to temp file")
+  end
+
   local args = {
     "--silent",
     "--no-buffer",
     "--header " .. vim.fn.shellescape("Authorization: Bearer " .. api_key),
     "--header " .. vim.fn.shellescape("Content-Type: application/json"),
     "--url " .. vim.fn.shellescape(url),
-    "--data " .. vim.fn.shellescape(json_request),
+    "--data-binary " .. vim.fn.shellescape("@" .. tmpfile),
   }
 
   -- hack for GitHub Copilot compatibility


### PR DESCRIPTION
This PR changes JSON request handling by writing to a temporary file instead of passing the string directly.

Changes include:
- Creation of a temporary file using `vim.fn.tempname()`
- Writing the JSON request string into the temporary file with `vim.fn.writefile`
- Adjusting the command line arguments to use the temporary file for the request body (`--data-binary @tmpfile`)
- Retaining headers for Authorization and Content-Type as before

This method enhances reliability for large or complex JSON payloads, avoiding shell escaping issues and command-line length limitations.

Overall, this enhances robustness of API calls that require JSON request bodies.
